### PR TITLE
Changed order of operations in AllocateTextures

### DIFF
--- a/RenderScripts/Filter.cs
+++ b/RenderScripts/Filter.cs
@@ -131,6 +131,11 @@ namespace Mpdn.RenderScript
 
         public virtual void AllocateTextures()
         {
+            foreach (var filter in InputFilters)
+            {
+                filter.AllocateTextures();
+            }
+            
             var size = OutputSize;
             if (OutputTexture == null || size.Width != OutputTexture.Width || size.Height != OutputTexture.Height)
             {
@@ -139,11 +144,6 @@ namespace Mpdn.RenderScript
                     Common.Dispose(OutputTexture);
                 }
                 OutputTexture = null;
-            }
-
-            foreach (var filter in InputFilters)
-            {
-                filter.AllocateTextures();
             }
 
             if (OutputTexture == null)


### PR DESCRIPTION
If you are reusing the texture of another filter, then by first allocating the textures for the inputFilters before disposing checking if OutputTexture has the correct size, you have a chance that m_TextureOwner.OutputTexture has already been resized to the correct size.

In an even extremer example. If you are only reusing InputRenderTarget and OutputRenderTarget (which is usually the case in the Image Processing script) then those will already have been resized so AllocateTextures doesn't need to do anything, even when you resize the window.

I don't think you'll gain much extra performance this way, but it is nice.
