### PR TITLE
Improve numerical stability, preserve alpha

### DIFF
--- a/RenderScripts/ImageProcessingShaders/ConvertToGammaLight.hlsl
+++ b/RenderScripts/ImageProcessingShaders/ConvertToGammaLight.hlsl
@@ -10,5 +10,7 @@ float2  p1 : register(c1);
 
 float4 main(float2 tex : TEXCOORD0) : COLOR 
 {
-    return float4(pow(tex2D(s0, tex).rgb, 2.2), 1);
+    float4 c0 = tex2D(s0, tex);
+    c0.rgb = pow(saturate(c0.rgb), 2.2);
+    return c0;
 }

--- a/RenderScripts/ImageProcessingShaders/ConvertToLinearLight.hlsl
+++ b/RenderScripts/ImageProcessingShaders/ConvertToLinearLight.hlsl
@@ -10,5 +10,7 @@ float2  p1 : register(c1);
 
 float4 main(float2 tex : TEXCOORD0) : COLOR 
 {
-    return float4(pow(tex2D(s0, tex).rgb, 1/2.2), 1);
+    float4 c0 = tex2D(s0, tex);
+    c0.rgb = pow(saturate(c0.rgb), 1/2.2);
+    return c0;
 }


### PR DESCRIPTION
The 'pow' function doesn't work on negative values, so you should call saturate first.
Also made it preserve the alpha channel, can't think of a good reason why you shouldn't.
