### PR TITLE
Quick fix for rare SuperRes bug

### DIFF
--- a/RenderScripts/Shiandow.SuperRes.cs
+++ b/RenderScripts/Shiandow.SuperRes.cs
@@ -102,7 +102,8 @@ namespace Mpdn.RenderScript
                         lab = new ResizeFilter(nedi, currentSize, m_ShiftedScaler, m_ShiftedScaler);
 
                         if (currentSize == nedi.OutputSize)
-                            throw new InvalidOperationException("TODO: implement a way to shift NEDI without resizing");
+                            // TODO: implement a proper way to shift NEDI without resizing
+                            lab = new ResizeFilter(lab, currentSize);
                     }
                     else lab = new ResizeFilter(lab, currentSize);
                     linear = new ShaderFilter(LabToLinear, lab);


### PR DESCRIPTION
1 pass + NEDI + 200% resizing = error.

Relatedly, could you make Render.Scale also resize even when the size is the same? Or at least add a way to do that.
